### PR TITLE
bump modelchecker to 2.18

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ N&S Dependency Loader changelog
 1.0.7 (unreleased)
 ------------------
 
-- Bumped threedi-modelchecker to 2.18.0
+- Bumped threedi-modelchecker to 2.18.1
 
 
 1.0.6 (2025-04-11)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ N&S Dependency Loader changelog
 1.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Bumped threedi-modelchecker to 2.18.0
 
 
 1.0.6 (2025-04-11)

--- a/dependencies.py
+++ b/dependencies.py
@@ -36,7 +36,7 @@ DEPENDENCIES = [
     Dependency("alembic", "alembic", "==1.14.*", False),
     Dependency("threedigrid", "threedigrid", "==2.3.*", False),
     Dependency("threedi-schema", "threedi_schema", "==0.300.26", False),
-    Dependency("threedi-modelchecker", "threedi_modelchecker", "==2.17.13", False),
+    Dependency("threedi-modelchecker", "threedi_modelchecker", "==2.18.0", False),
     Dependency("threedidepth", "threedidepth", "==0.6.3", False),
     Dependency("click", "click", ">=8.0", False),
     Dependency("packaging", "packaging", "", False),

--- a/dependencies.py
+++ b/dependencies.py
@@ -36,7 +36,7 @@ DEPENDENCIES = [
     Dependency("alembic", "alembic", "==1.14.*", False),
     Dependency("threedigrid", "threedigrid", "==2.3.*", False),
     Dependency("threedi-schema", "threedi_schema", "==0.300.26", False),
-    Dependency("threedi-modelchecker", "threedi_modelchecker", "==2.18.0", False),
+    Dependency("threedi-modelchecker", "threedi_modelchecker", "==2.18.1", False),
     Dependency("threedidepth", "threedidepth", "==0.6.3", False),
     Dependency("click", "click", ">=8.0", False),
     Dependency("packaging", "packaging", "", False),


### PR DESCRIPTION
I'm keeping this a pr until https://github.com/nens/threedi-results-analysis/pull/1101 is approved and no changes to the modelchecker are needed.