### PR TITLE
Bump modelchecker to 2.18.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ N&S Dependency Loader changelog
 -------------------
 
 - Restrained click version.
+- Bump modelchecker to 2.18.4
 
 
 1.0.11 (2025-05-12)

--- a/dependencies.py
+++ b/dependencies.py
@@ -36,7 +36,7 @@ DEPENDENCIES = [
     Dependency("alembic", "alembic", "==1.14.*", False),
     Dependency("threedigrid", "threedigrid", "==2.3.5", False),
     Dependency("threedi-schema", "threedi_schema", "==0.300.26", False),
-    Dependency("threedi-modelchecker", "threedi_modelchecker", "==2.18.3", False),
+    Dependency("threedi-modelchecker", "threedi_modelchecker", "==2.18.4", False),
     Dependency("threedidepth", "threedidepth", "==0.6.3", False),
     Dependency("click", "click", ">=8.0, <8.2", False),
     Dependency("packaging", "packaging", "", False),


### PR DESCRIPTION
Bum modelchecker to version with fixes in geometry exporter